### PR TITLE
Add angle of attack + sideslip message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ornen/go-xplane
+
+go 1.17

--- a/messages/angleofattack.go
+++ b/messages/angleofattack.go
@@ -15,19 +15,27 @@
 package messages
 
 const (
-	SpeedMessageType              = 3
-	GLoadMessageType              = 4
-	WeatherMessageType            = 6
-	FlightControlMessageType      = 11
-	TrimFlapsBrakesMessageType    = 13
-	GearsBrakesMessageType        = 14
-	PitchRollHeadingMessageType   = 17
-	LatLonAltMessageType          = 20
-	LocVelDistTraveledMessageType = 21
-	EngineRPMMessageType          = 37
-	PropRPMMessageType            = 38
-	PropPitchMessageType          = 39
-	BatteryAmperageMessageType    = 53
-	BatteryVoltageMessageType     = 54
 	AngleOfAttackSideslipMessageType = 18
 )
+
+type AngleOfAttackSideslipMessage struct {
+	Alpha float64
+	Beta float64
+	HPath float64
+	VPath float64
+	Slip float64
+}
+
+func NewAngleOfAttackSideslipMessage(data []float32) AngleOfAttackSideslipMessage {
+	return AngleOfAttackSideslipMessage{
+		Alpha: float64(data[0]),
+		Beta: float64(data[1]),
+		HPath: float64(data[2]),
+		VPath: float64(data[3]),
+		Slip: float64(data[4]),
+	}
+}
+
+func (m AngleOfAttackSideslipMessage) Type() uint {
+	return AngleOfAttackSideslipMessageType
+}

--- a/messages/angleofattack.go
+++ b/messages/angleofattack.go
@@ -14,10 +14,6 @@
 
 package messages
 
-const (
-	AngleOfAttackSideslipMessageType = 18
-)
-
 type AngleOfAttackSideslipMessage struct {
 	Alpha float64
 	Beta float64

--- a/xplane.go
+++ b/xplane.go
@@ -134,6 +134,8 @@ func (x *XPlane) parse(sentence []byte) {
 		x.Messages <- messages.NewPropRPMMessage(messageData)
 	case messages.PropPitchMessageType:
 		x.Messages <- messages.NewPropPitchMessage(messageData)
+	case messages.AngleOfAttackSideslipMessageType:
+		x.Messages <- messages.NewAngleOfAttackSideslipMessage(messageData)
 	default:
 		log.Println("Unknown message type: ", messageType)
 	}


### PR DESCRIPTION
Adds the angle of attach, sideslip and path message.
Adds `go.mod` to support local `replace` based development.